### PR TITLE
Fixed the "https://ip-api.com" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@ invaders must die ;)
           <div class="list-card">
             <div>
               <p>Note that Kratzaeditts just found a random IP and wants to harm the person owning this IP to get someone interested in him.</p>
-              <p>People who do this are generally trying to be scary by dropping random information, like <em>&quot;Your city is <span id="city">&lt;Some city&gt;</span>&quot;</em> that they just found by typing <span id="ipadr">127.0.0.1</span> into <a href="https://ip-api" target="_blank">ip-api.com</a>.</p>
+              <p>People who do this are generally trying to be scary by dropping random information, like <em>&quot;Your city is <span id="city">&lt;Some city&gt;</span>&quot;</em> that they just found by typing <span id="ipadr">127.0.0.1</span> into <a href="https://ip-api.com" target="_blank">ip-api.com</a>.</p>
               <p>The same goes for:</p>
               <ul>
                 <li>&quot;YOU LEAKED YOUR IP!!!&quot;</li>


### PR DESCRIPTION
"ip-api.com" didn't open "https://ip-api.com" but "https://ip-api"

![image](https://github.com/user-attachments/assets/cd741cc5-c641-4e3d-8e6e-701853dcb5f9)
