### PR TITLE
updated Url parameter -> url fragment in achievements (config.php)

### DIFF
--- a/website/api/config.php
+++ b/website/api/config.php
@@ -187,7 +187,7 @@ $achievements = [
     [
         'name' => 'URL Hacker',
         'percent' => 38,
-        'description' => 'Access a feature using a URL parameter',
+        'description' => 'Access a feature using a URL fragment (#)',
         'time' => 0
     ],
     [


### PR DESCRIPTION
The technical term wasnt correct:
An url parameter is the ?<params> part, and framents are the #<frament> part
https://noskid.today#coolFeature is a fragment and not a parameter